### PR TITLE
Add inactive record update examples

### DIFF
--- a/python/using_pyairtable/example.py
+++ b/python/using_pyairtable/example.py
@@ -81,4 +81,23 @@ Table.batch_create(recordsToCreate)
 # Perform record updates on existing records
 Table.batch_update(recordsToUpdate)
 
+# Uncomment the following block of code if you wish to set records in Airtable # that do not exist in
+# your inputRecords dataset. The example code assumes you have a checkbox field named "Inactive"
+# # Create sets of unique ID values for both input and existing records
+# inputRecordsUpsertFieldValues = set([
+#     d[AIRTABLE_UNIQUE_FIELD_NAME] for d in inputRecords])
+# allExistingRecordsUpsertFieldValues = set([
+#     d['fields'][AIRTABLE_UNIQUE_FIELD_NAME] for d in allExistingRecords])
+# # Determine which unique ID values are not present in input records
+# existingRecordsUpsertFieldValuesNotPresentInInputRecords = allExistingRecordsUpsertFieldValues.difference(
+#     inputRecordsUpsertFieldValues)
+# # Create list of dictionaries representing Airtable update record API payloads
+# recordsToUpdateAsInactive = [{'id': upsertFieldValueToExistingRecordId.get(
+#     recordUniqueValue), 'fields': {'Inactive': True}}
+#     for recordUniqueValue in existingRecordsUpsertFieldValuesNotPresentInInputRecords]
+# print("\n{} records to set Inactive=true (unique ID exists in Airtable records but not in input data source)".format(
+#     len(recordsToUpdateAsInactive)))
+# # Perform record updates on existing records that are now considered 'Inactive'
+# Table.batch_update(recordsToUpdateAsInactive)
+
 print("\n\nScript execution complete!")


### PR DESCRIPTION
The existing generic update examples do not have a way to update existing Airtable records as "inactive" if their unique ID is no longer present in the "input" data set.

This PR updates these examples to have that functionality (though commented out by default)
- [x] Python - pyAirtable
- [ ] Javascript - Airtable Scripting
- [ ] Javascript - Airtable.js
- [ ] Javascript - node-fetch
- [ ] R -  airtabler
- [ ] Ruby - Airrrecord